### PR TITLE
Adding more generic checks for xrandr and freebsd support

### DIFF
--- a/src/mons.sh
+++ b/src/mons.sh
@@ -132,11 +132,8 @@ main() {
         esac
     done
 
-    if [ -f "/usr/bin/xrandr" ]; then
-        XRANDR="/usr/bin/xrandr"
-    elif [ -f "/bin/xrandr" ]; then
-        XRANDR="/bin/xrandr"
-    else
+    XRANDR=$(command -v xrandr)
+    if [ "$?" -ne 0 ]; then
         echo "xrandr: command not found." ; exit 1
     fi
 


### PR DESCRIPTION
Freebsd puts the xrandr binary in `/usr/local/bin/xrandr`. Instead I just made the check more generic.

Appreciate the project, comes in handy for my freebsd/i3 laptop install!

Let me know if you need me to consider anything else.

~Rob