### PR TITLE
restrict grep so that it works with displays with similar names

### DIFF
--- a/mons
+++ b/mons
@@ -155,8 +155,8 @@ main() {
     if [ "$#" -eq 0 ]; then
         i=0
         for mon in ${mons}; do
-            if echo "${plug_mons}" | grep "${mon}" > /dev/null; then
-                if echo "${disp_mons}" | grep "${mon}" > /dev/null; then
+            if echo "${plug_mons}" | grep "^${mon}$" > /dev/null; then
+                if echo "${disp_mons}" | grep "^${mon}$" > /dev/null; then
                     state='(enabled)'
                 fi
                 printf '%-3s %-9s %-9s\n' "${i}:" "${mon}" "${state}"


### PR DESCRIPTION
I have an internal display named DP1 and an external display eDP1. These are both detected as the same display since mons greps for the name and "DP1" is included in "eDP1". This PR restricts the grep so that it matches the whole name of a display.