### PR TITLE
make: fix non-default install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ install: $(LIB) $(MANPAGE)
 	cp LICENSE $(LICENSEDIR)/LICENSE
 	cp $(MANPAGE) $(MANDIR)/$(MANPAGE)
 	cp $(SCRIPT) $(BINDIR)/$(PKGNAME)
+	sed -i -e "s#%LIBDIR%#$(LIBDIR)#" $(BINDIR)/$(PKGNAME)
 
 $(MANPAGE):
 	help2man -N -n "$(PKGDESC)" -h -h -v -v ./$(SCRIPT) | gzip - > $@

--- a/mons.sh
+++ b/mons.sh
@@ -82,7 +82,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 # Helps to generate manpage with help2man before installing the library
 [ "$1" = '-h' ] && { usage; exit; }
 [ "$1" = '-v' ] && { version; exit; }
-lib='/usr/lib/libshlist/liblist.sh'
+lib='%LIBDIR%/liblist.sh'
 [ ! -r "$lib" ] && { "$lib: library not found."; exit 1; }
 . "$lib"
 


### PR DESCRIPTION
Using custom DESTDIR makes it fail with
"/usr/lib/libshlist/liblist.sh: library not found" message.

 % DESTDIR=$HOME/.local make install
mkdir -p /home/gr/.local/usr/lib/libshlist
mkdir -p /home/gr/.local/usr/share/licenses/mons
mkdir -p /home/gr/.local/usr/share/man/man1
mkdir -p /home/gr/.local/usr/bin
chmod 644 libshlist/liblist.sh
chmod 644 LICENSE
chmod 644 mons.1.gz
chmod 755 mons.sh
cp libshlist/liblist.sh /home/gr/.local/usr/lib/libshlist/liblist.sh
cp LICENSE /home/gr/.local/usr/share/licenses/mons/LICENSE
cp mons.1.gz /home/gr/.local/usr/share/man/man1/mons.1.gz
cp mons.sh /home/gr/.local/usr/bin/mons
 % /home/gr/.local/usr/bin/mons
/home/gr/.local/usr/bin/mons: line 86: /usr/lib/libshlist/liblist.sh: library not found.: No such file or directory

Hence, replace hardcoded libshlist path with %LIBDIR% pattern.

Signed-off-by: grygorii <grembeter@outlook.com>