### PR TITLE
added PREFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ PKGDESC     := POSIX Shell script to quickly manage 2-monitors display.
 SCRIPT      = $(PKGNAME).sh
 MANPAGE     = $(PKGNAME).1.gz
 
-LICENSEDIR  = $(DESTDIR)/usr/share/licenses/$(PKGNAME)
-MANDIR      = $(DESTDIR)/usr/share/man/man1
-BINDIR      = $(DESTDIR)/usr/bin
-LIBDIR      = $(DESTDIR)/usr/lib/libshlist
+PREFIX      = /usr
+LICENSEDIR  = $(DESTDIR)$(PREFIX)/share/licenses/$(PKGNAME)
+MANDIR      = $(DESTDIR)$(PREFIX)/share/man/man1
+BINDIR      = $(DESTDIR)$(PREFIX)/bin
+LIBDIR      = $(DESTDIR)$(PREFIX)/lib/libshlist
 
 LIB         = libshlist/liblist.sh
 


### PR DESCRIPTION
This PR adds a variable `PREFIX` which lets the user choose an installation directory other than `$(DESTDIR)/usr/bin`. This is needed e.g. to package mons for for NixOS which requires  `$(DESTDIR)/bin`.
The new `PREFIX` variable defaults to `/usr` and is hence backwards compatible.