### PR TITLE
Fixing command builtin for freebsd

### DIFF
--- a/mons.sh
+++ b/mons.sh
@@ -151,8 +151,15 @@ main() {
     # =============================
 
     [ -z "$DISPLAY" ]  && { echo 'DISPLAY: no variable set.';  exit 1; }
-    command -vp xrandr >/dev/null 2>&1 || { echo 'xrandr: command not found.'; exit 1; }
-    XRANDR="$(command -pv xrandr)"
+
+    if command -v xrandr >/dev/null 2>&1 ; then
+      XRANDR="$(command -v xrandr)"
+    elif command -vp xrandr >/dev/null 2>&1 ; then
+      XRANDR="$(command -pv xrandr)"
+    else
+      echo 'xrandr: command not found.'
+      exit 1
+    fi
 
     # =============================
     #      Argument Checking


### PR DESCRIPTION
## Description

Depends on: https://github.com/Ventto/libshlist/pull/2
Closes: #30 

It does not seem that "command -pv xrandr" is able to find xrandr in my PATH on FreeBSD. Im not sure if this is due to there just not being a default /etc/environment set or what but I think we should be checking
the current PATH as well as the default to make sure we search all possibilities.

Let me know what you think.

## Tests

Building with my PR from libshlist: https://github.com/Ventto/libshlist/pull/2 nets me the expect results:

```
mkdir build
make install PREFIX=$(realpath ./build) LIB=$(realpath ../libshlist/liblist.sh)
...
$ build/bin/mons
Monitors:        2
Mode: primary
0:*  LVDS-1   (enabled)
```
