### PR TITLE
Add 'echo' to properly print error when liblist.sh not found

### DIFF
--- a/mons.sh
+++ b/mons.sh
@@ -83,7 +83,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 [ "$1" = '-h' ] && { usage; exit; }
 [ "$1" = '-v' ] && { version; exit; }
 lib='%LIBDIR%/liblist.sh'
-[ ! -r "$lib" ] && { "$lib: library not found."; exit 1; }
+[ ! -r "$lib" ] && { echo "$lib: library not found."; exit 1; }
 . "$lib"
 
 arg_err() {


### PR DESCRIPTION
Due to a missing `echo`, `mon.sh` would fail without printing the correct error message if **liblist.sh** was not found