### PR TITLE
Use xrandr to find number of monitors

### DIFF
--- a/mons.sh
+++ b/mons.sh
@@ -268,9 +268,13 @@ main() {
     if $aFlag ; then
         prev=0; i=0
         while true; do
-            for status in /sys/class/drm/*/status; do
-                [ "$(<"$status")" = 'connected' ] && i=$((i+1))
-            done
+            i=$($XRANDR | grep -Po '[^dis]connected' | wc -l)
+	        if [ $i -gt 1 ]; then
+	    	    MONITORS_LIST=$($XRANDR | grep -Po '.+[^dis]connected' | cut -sd' ' -f1)
+	    	    for monitor in $MONITORS_LIST; do
+			        [[ "LVDS-0" = $monitor && "closed" = $(cat /proc/acpi/button/lid/LID/state | grep -Po '(?<=state:).+$' | grep -Po '[^\s].+$') ]] && i=$((i-1))
+	    	    done
+	        fi
 
             if [ "$i" != "$prev" ]; then
                 if $xFlag; then


### PR DESCRIPTION
On some Linux systems, there exist no file such as "/sys/class/drm/*/status" (might be related to the usage of NVIDIA drivers, but I am not sure). Instead of relying on the given number of these files, we can use xrandr (plus some grepping and additional logic) to extract the number of monitors.

This Pull Request **resolves** Issue #51 