### PR TITLE
feature: center monitors on extend

### DIFF
--- a/mons.sh
+++ b/mons.sh
@@ -469,12 +469,12 @@ main() {
 
         if $eFlag ; then
             primary="$(list_front "$plug_mons")"
-            size_primary="$(echo "$xrandr_out" | grep "$primary" | grep -oE '[0-9]+x[0-9]+')"
+            size_primary="$(echo "$xrandr_out" | grep "$primary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
             x_primary="$(echo "$size_primary" | cut -d'x' -f1)"
             y_primary="$(echo "$size_primary" | cut -d'x' -f2)"
 
             secondary="$(list_get 1 "$plug_mons")"
-            size_secondary="$(echo "$xrandr_out" | grep "$secondary" | grep -oE '[0-9]+x[0-9]+')"
+            size_secondary="$(echo "$xrandr_out" | grep "$secondary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
             x_secondary="$(echo "$size_secondary" | cut -d'x' -f1)"
             y_secondary="$(echo "$size_secondary" | cut -d'x' -f2)"
 

--- a/mons.sh
+++ b/mons.sh
@@ -469,12 +469,22 @@ main() {
 
         if $eFlag ; then
             primary="$(list_front "$plug_mons")"
-            size_primary="$(echo "$xrandr_out" | grep "^$primary " -A99 | tail -n +2 | grep '\*' -m 1 | awk '{print $1}')"
+            # NOTE: specifying both + and * here might introduce issues
+            # last time we did because * was not there when on secondary only
+            size_primary="$(echo "$xrandr_out" | grep "^$primary " -A99 | tail -n +2 | grep '[\*\+]' -m 1 | awk '{print $1}')"
+            # NOTE: this is for when the monitor is not active (just take the highest resolution)
+            if [ -z "$size_primary" ]; then
+                size_primary="$(echo "$xrandr_out" | grep "^$primary " -A99 | head -n 2 | tail -1 | awk '{print $1}')"
+            fi
             x_primary="$(echo "$size_primary" | cut -d'x' -f1)"
             y_primary="$(echo "$size_primary" | cut -d'x' -f2)"
 
             secondary="$(list_get 1 "$plug_mons")"
-            size_secondary="$(echo "$xrandr_out" | grep "^$secondary " -A99 | tail -n +2 | grep '\*' -m 1 | awk '{print $1}')"
+            size_secondary="$(echo "$xrandr_out" | grep "^$secondary " -A99 | tail -n +2 | grep '[\*\+]' -m 1 | awk '{print $1}')"
+            # NOTE: this is for when the monitor is not active (just take the highest resolution)
+            if [ -z "$size_secondary" ]; then
+                size_secondary="$(echo "$xrandr_out" | grep "^$secondary " -A99 | head -n 2 | tail -1 | awk '{print $1}')"
+            fi
             x_secondary="$(echo "$size_secondary" | cut -d'x' -f1)"
             y_secondary="$(echo "$size_secondary" | cut -d'x' -f2)"
 

--- a/mons.sh
+++ b/mons.sh
@@ -469,12 +469,12 @@ main() {
 
         if $eFlag ; then
             primary="$(list_front "$plug_mons")"
-            size_primary="$(echo "$xrandr_out" | grep "$primary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
+            size_primary="$(echo "$xrandr_out" | grep "^$primary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
             x_primary="$(echo "$size_primary" | cut -d'x' -f1)"
             y_primary="$(echo "$size_primary" | cut -d'x' -f2)"
 
             secondary="$(list_get 1 "$plug_mons")"
-            size_secondary="$(echo "$xrandr_out" | grep "$secondary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
+            size_secondary="$(echo "$xrandr_out" | grep "^$secondary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
             x_secondary="$(echo "$size_secondary" | cut -d'x' -f1)"
             y_secondary="$(echo "$size_secondary" | cut -d'x' -f2)"
 

--- a/mons.sh
+++ b/mons.sh
@@ -469,12 +469,12 @@ main() {
 
         if $eFlag ; then
             primary="$(list_front "$plug_mons")"
-            size_primary="$(echo "$xrandr_out" | grep "^$primary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
+            size_primary="$(echo "$xrandr_out" | grep "^$primary " -A99 | tail -n +2 | grep '\*' -m 1 | awk '{print $1}')"
             x_primary="$(echo "$size_primary" | cut -d'x' -f1)"
             y_primary="$(echo "$size_primary" | cut -d'x' -f2)"
 
             secondary="$(list_get 1 "$plug_mons")"
-            size_secondary="$(echo "$xrandr_out" | grep "^$secondary" -A99 | tail -n +2 | grep + -m 1 | awk '{print $1}')"
+            size_secondary="$(echo "$xrandr_out" | grep "^$secondary " -A99 | tail -n +2 | grep '\*' -m 1 | awk '{print $1}')"
             x_secondary="$(echo "$size_secondary" | cut -d'x' -f1)"
             y_secondary="$(echo "$size_secondary" | cut -d'x' -f2)"
 


### PR DESCRIPTION
I usually use mons when I connect my laptop to some external display. When I have no keyboard I like to have my laptop sitting in front of me with the external display on top. The mons script currently does not center both monitors when extending. This PR implements that.

I'm not sure if this breaks some other commands. It works reliably for me. It also works for extending left/right/bottom.
We need to discuss if this should be the default behavior or if this new behavior should be enabled by some flag.

old behavior:
![old](https://user-images.githubusercontent.com/4995833/192157947-5508ce21-0440-4a7a-8f46-0241c8d81260.png)

new behavior:
![new](https://user-images.githubusercontent.com/4995833/192157944-5c82a825-e4de-4427-ab3b-ad1bdfc3cf87.png)
